### PR TITLE
Fix parentheses-related typos

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -85,7 +85,7 @@ pagetype: home
 <p>Effect handlers are exception handlers on steroids! Like with exceptions, we first define the type of the
   exception. In Effekt, a declaration like <code class="language-effekt">Yield</code> is called an <emph>effect signature</emph>.</p>
 
-<p>Calling an effect operation (with <code class="language-effekt">do Yield(42)</code> is like throwing an exception. It
+<p>Calling an effect operation (with <code class="language-effekt">do Yield(42)</code>) is like throwing an exception. It
 transfers the control-flow to the handler that catches (or "handles") the effect. We can also
 send values to the handler (here <code class="language-effekt">n</code>).</p>
 </div>

--- a/index.md
+++ b/index.md
@@ -29,10 +29,10 @@ If you are interested in the Effekt language, we have a few things to get you st
 
 <div id="start-guide">
 <h3>Quick Guides</h3>
-<p>To get a first impression of the distinguishing features, read the quick-guides on this page (
-  <a href="#intro-handlers">effect handlers</a>,
-  <a href="#intro-safety">effect safety</a>,
-  <a href="#intro-polymorphism">effect polymorphism</a>).
+<p>To get a first impression of the distinguishing features, read the quick-guides on this page
+  (<a href="#intro-handlers">effect handlers</a>,
+   <a href="#intro-safety">effect safety</a>,
+   <a href="#intro-polymorphism">effect polymorphism</a>).
 </p>
 </div>
 


### PR DESCRIPTION
Hi,

I was reading your website and encountered few typos on the Home page. I took the liberty of correcting it. :)

- Deleted whitespace occurring after opening parenthesis in the Quick Guides section.
  - Not sure about the new placement of the opening parenthesis. Although it works, the new formatting of the links might be a bit odd.
- Added closing parenthesis in the Effect Handlers section.