### PR TITLE
Change Github Action to create PR for compiler update

### DIFF
--- a/.github/workflows/update-compiler.yml
+++ b/.github/workflows/update-compiler.yml
@@ -59,6 +59,7 @@ jobs:
             dist/
             effekt/
           commit-message: "Github Action: update compiler"
+          base: master
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: update-compiler

--- a/.github/workflows/update-compiler.yml
+++ b/.github/workflows/update-compiler.yml
@@ -47,16 +47,23 @@ jobs:
         run: |
           npm install
           npx webpack
-    
-      - name: Commit updated compiler and submodule update
-        run: |
-          git config --global user.email "action@github.com"
-          git config --global user.name "GitHub Action"
-          git add src/ dist/ effekt/
-          git commit -m "Github Action: update compiler $(git -C effekt show -s --format=%h)"
-      
-      - name: Push changes
+  
+      - name: Open Pull Request
         # here we have to make sure that trigger event is on 'manual'
         # since 'on push' could cause a infinite loop of actions triggering each other
         if: github.event_name == 'workflow_dispatch'
-        run: git push
+        uses: peter-evans/create-pull-request@v5
+        with:
+          add-paths: |
+            src/
+            dist/
+            effekt/
+          commit-message: "Github Action: update compiler"
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          branch: update-compiler
+          title: '[Action] Update compiler'
+          body: |
+            Update Effekt compiler on the website.
+          reviewers: dvdvgt
+          draft: false

--- a/.github/workflows/update-compiler.yml
+++ b/.github/workflows/update-compiler.yml
@@ -60,11 +60,10 @@ jobs:
             effekt/
           commit-message: "Github Action: update compiler"
           base: master
-          committer: GitHub <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          branch: update-compiler
-          title: '[Action] Update compiler'
-          body: |
-            Update Effekt compiler on the website.
-          reviewers: dvdvgt
+          branch: action/update-compiler
+          title: "[Github Action] Update compiler"
+          body: "Update Effekt compiler on the website."
+          reviewers: |
+            b-studios
+            dvdvgt
           draft: false


### PR DESCRIPTION
Previously the "update compiler" workflow tried to push directly to the master branch. However, due to branch protection this resulted in an error. Now the action opens a new PR instead and requires permission for merging (see #40). I added @b-studios and myself as reviewers for these automated PR.