### PR TITLE
Add special symbols to highlighting

### DIFF
--- a/src/effekt-syntax.ts
+++ b/src/effekt-syntax.ts
@@ -33,7 +33,7 @@ export const syntax = <ILanguage>{
   tokenizer: {
     root: [
       // identifiers and keywords
-      [/[a-z_$][\w$]*/, {
+      [/[a-z_$][\w$?!]*/, {
         cases: {
           '@keywords': {
             cases: {
@@ -46,7 +46,7 @@ export const syntax = <ILanguage>{
         }
       }],
 
-      [/[A-Z][\w\$]*/, 'type.identifier' ],
+      [/[A-Z][\w\$?!]*/, 'type.identifier' ],
 
       // whitespace
       { include: '@whitespace' },
@@ -76,7 +76,7 @@ export const syntax = <ILanguage>{
 
     definition: [
       { include: '@whitespace' },
-      [/[a-zA-Z_$][\w$]*/, 'definition'],
+      [/[a-zA-Z_$][\w$?!]*/, 'definition'],
       [new RegExp(""),'','@pop']
     ],
 

--- a/src/highlight-effekt.js
+++ b/src/highlight-effekt.js
@@ -17,7 +17,7 @@ hljs.registerLanguage("effekt", function highlightEffekt(hljs) {
   var SUBST = {
     className: 'subst',
     variants: [
-      {begin: '\\$[A-Za-z0-9_]+'},
+      {begin: '\\$[A-Za-z0-9_?!]+'},
       {begin: '\\${', end: '}'}
     ]
   };
@@ -51,12 +51,12 @@ hljs.registerLanguage("effekt", function highlightEffekt(hljs) {
 
   var SYMBOL = {
     className: 'symbol',
-    begin: '\'\\w[\\w\\d_]*(?!\')'
+    begin: '\'\\w[\\w\\d_?!]*(?!\')'
   };
 
   var TYPE = {
     className: 'type',
-    begin: '\\b[A-Z][A-Za-z0-9_]*',
+    begin: '\\b[A-Z][A-Za-z0-9_?!]*',
     relevance: 0
   };
 


### PR DESCRIPTION
After https://github.com/effekt-lang/effekt/pull/419, this PR adds support for the special symbols `?` and `!` in identifiers.

Before:
![image](https://github.com/effekt-lang/effekt-website/assets/32108934/18ef7a7d-664a-43c6-81ab-bf1bc4cd01cb)

After:
![image](https://github.com/effekt-lang/effekt-website/assets/32108934/2829baf0-ca3d-4541-a837-07a52240c186)
