### PR TITLE
Update tagline to mention lexical handlers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ url: 'https://effekt-lang.org'
 baseurl:
 githuburl: https://github.com/effekt-lang/effekt
 githuburl_website: https://github.com/effekt-lang/effekt-website
-description: A research language with effect handlers and lightweight effect polymorphism
+description: A language with lexical effect handlers and lightweight effect polymorphism
 docs: true
 
 collections:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="author" content="the Effekt research team" />
-    <meta name="description" content="A research language with effect handlers and lightweight effect polymorphism" />
+    <meta name="description" content="A language with lexical effect handlers and lightweight effect polymorphism" />
     <meta name="og:image" content="{{site.url}}{{site.baseurl}}/img/poster.png" />
     <meta name="image" property="og:image" content="{{site.url}}{{site.baseurl}}/img/poster.png" />
     <meta name="og:title" content="Effekt Language{% if page.title %}: {{page.title}}{% endif %}" />
@@ -14,11 +14,11 @@
     <meta name="og:site_name" content="Effekt Language" />
     <meta name="og:url" content="" />
     <meta name="og:type" content="website" />
-    <meta name="og:description" content="A research language with effect handlers and lightweight effect polymorphism" />
+    <meta name="og:description" content="A language with lexical effect handlers and lightweight effect polymorphism" />
     <link rel="icon" type="image/png" href="{{site.url}}{{site.baseurl}}/img/favicon.png" />
     <meta name="twitter:title" content="Effekt Language{% if page.title %}: {{page.title}}{% endif %}" />
     <meta name="twitter:image" content="{{site.baseurl}}/img/poster.png" />
-    <meta name="twitter:description" content="A research language with effect handlers and lightweight effect polymorphism" />
+    <meta name="twitter:description" content="A language with lexical effect handlers and lightweight effect polymorphism" />
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="icon" type="image/png" sizes="16x16" href="{{site.url}}{{site.baseurl}}/img/favicon.png" />
     <link rel="icon" type="image/png" sizes="24x24" href="{{site.url}}{{site.baseurl}}/img/favicon.png" />

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -10,7 +10,7 @@ pagetype: home
         <div class="features-header-description">
             <h1 class="masthead-title">Effekt Language</h1>
             <p class="masthead-description">
-              A research language with effect handlers and lightweight effect polymorphism
+              A language with lexical effect handlers and lightweight effect polymorphism
             </p>
             <a href="quickstart" class="masthead-button">Try it yourself!</a></div>
         <div class="features-image">


### PR DESCRIPTION
Found all occurences of the old tagline:
```html
$ rg "A research language with effect handlers and lightweight effect polymorphism"

_config.yml
6:description: A research language with effect handlers and lightweight effect polymorphism

_layouts/default.html
9:    <meta name="description" content="A research language with effect handlers and lightweight effect polymorphism" />
17:    <meta name="og:description" content="A research language with effect handlers and lightweight effect polymorphism" />
21:    <meta name="twitter:description" content="A research language with effect handlers and lightweight effect polymorphism" />

_layouts/home.html
13:              A research language with effect handlers and lightweight effect polymorphism
```
and changed them to
```
A language with lexical effect handlers and lightweight effect polymorphism
```