### PR TITLE
Fix links to docs after #79

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -46,7 +46,7 @@ pagetype: home
     <div class="warn container">
      <p>Effekt is a <strong>research-level</strong> language &mdash; use at your own risk! While we are heavily
      working on it, there are probably many bugs and many things will change in the future.
-     Of course, we are happy if you <a href="docs/">try it out</a> and report your experience with it.</p>
+     Of course, we are happy if you <a href="docs">try it out</a> and report your experience with it.</p>
      <p>Have fun!</p>
     </div>
     <section class="container">

--- a/index.md
+++ b/index.md
@@ -48,7 +48,7 @@ If you are interested in the Effekt language, we have a few things to get you st
 
 <div id="start-install">
 <h3>Installation Guide</h3>
-<p>To install Effekt and try the examples on your own computer you can follow the <a href="docs/">installation instructions</a>.</p>
+<p>To install Effekt and try the examples on your own computer you can follow the <a href="docs">installation instructions</a>.</p>
 </div>
 
 <div id="start-read">

--- a/quickstart.md
+++ b/quickstart.md
@@ -6,7 +6,7 @@ position: 2
 ---
 
 # Try Effekt Online
-You can immediately experiment with the Effekt language, without [installing](docs/) it.
+You can immediately experiment with the Effekt language, without [installing](docs) it.
 
 Effekt is a research language, we recommend reading [the papers](https://se.cs.uni-tuebingen.de/research/handlers/effekt/) describing important design decisions and the inner workings of Effekt.
 


### PR DESCRIPTION
The `docs/` link from #79 doesn't seem to work on the website, the link is:
```
https://effekt-lang.org/docs/
```
but it should be:
```
https://effekt-lang.org/docs
```