### PR TITLE
Add edit/source button

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -63,6 +63,13 @@ pagetype: docs
                           <ul class="pull-right">
                             <li><a href="{{ site.githuburl }}" target="_blank" rel="noopener noreferrer"><span class="nav-item-text">GitHub</span></a></li>
                             <li><a href="{{ site.baseurl }}/docs"><span class="nav-item-text">Documentation</span></a></li>
+                            <li>
+                              <a href="https://github.com/effekt-lang/{{ page.origin | default: 'effekt-website' }}/blob/master/{{ page.path }}" 
+                               target="_blank" 
+                               rel="noopener noreferrer">
+                                <span class="nav-item-text">✎ Found an error?</span>
+                              </a>
+                            </li>
                           </ul>
                         </div>
                     </div>


### PR DESCRIPTION
Closes #64 and adds a go-to-source/edit button to all pages using the `doc` layout. By default, the filename is chosen for computing the correct GitHub URL. In case the file is not part of the `effekt-website` repo, the parameter `origin` must be set to, for example, `effekt` in case of the language tour files.

![image](https://github.com/user-attachments/assets/29211314-bf95-487a-b3f3-059ec99052bc)

(The weird square is not related to this PR and is just because of some issue in my local deployment that has already existed before.)