### PR TITLE
Tour: Computations should be after Effects

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -18,8 +18,6 @@ options:
         url: /tour/values
       - title: Variables
         url: /tour/variables
-      - title: Computations
-        url: /tour/computation
       - title: Records
         url: /tour/records
       - title: Datatypes
@@ -30,6 +28,8 @@ options:
         url: /tour/functions
       - title: Effects
         url: /tour/effects
+      - title: Computations
+        url: /tour/computation
       - title: Objects
         url: /tour/objects
       - title: Captures


### PR DESCRIPTION
By now, I have three separate pieces of feedback saying that the "Computations" chapter is too much, too soon -- instead, we can/should talk about after effects (since it presumes the existence of effects, the syntax, etc.)

The only problem now is that the reader doesn't know how to write a higher-order function when looking into just the "Functions" chapter.