### PR TITLE
Add link to API

### DIFF
--- a/_includes/header-nav.html
+++ b/_includes/header-nav.html
@@ -8,6 +8,7 @@
             <ul>
                 <li><a href="{{ site.githuburl }}" target="_blank" rel="noopener noreferrer"><span class="nav-item-text">GitHub</span></a></li>
                 <li><a href="docs"><i class="nav-item-icon fa fa-lg fa-file-text" hidden="true"></i><span class="nav-item-text">Documentation</span></a></li>
+                <li><a href="https://effekt-lang.github.io/effekt-api/"><i class="nav-item-icon fa fa-lg fa-file-text" hidden="true"></i><span class="nav-item-text">API</span></a></li>
             </ul>
         </div>
     </div>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -63,6 +63,7 @@ pagetype: docs
                           <ul class="pull-right">
                             <li><a href="{{ site.githuburl }}" target="_blank" rel="noopener noreferrer"><span class="nav-item-text">GitHub</span></a></li>
                             <li><a href="{{ site.baseurl }}/docs"><span class="nav-item-text">Documentation</span></a></li>
+                            <li><a href="https://effekt-lang.github.io/effekt-api/"><span class="nav-item-text">API</span></a></li>
                           </ul>
                         </div>
                     </div>


### PR DESCRIPTION
Although the Effekt API in [effekt-api](https://github.com/effekt-lang/effekt-api) is still in alpha, I'm very much in favor of still linking to it in the navigation bar. Students seem to like it and I've heard that it was _essential_ for a positive Effekt experience.

We may also want to consider a different URL, e.g. `https://api.effekt-lang.org/`, cc @b-studios.